### PR TITLE
Add Bandit security linting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check linting
         run: uv run ruff check src/ tests/
 
+      - name: Security lint
+        run: uv run bandit -r src/
+
   test:
     runs-on: ubuntu-latest
     needs: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ packages = ["src/bifrost"]
 
 [dependency-groups]
 dev = [
+    "bandit>=1.8",
     "detect-secrets==1.5.0",
     "pip-audit>=2.7",
     "pre-commit>=4.5.1",

--- a/src/bifrost/__main__.py
+++ b/src/bifrost/__main__.py
@@ -60,7 +60,7 @@ def main() -> None:
     # Start the web server (blocks until stopped)
     uvicorn.run(
         web_app.app,
-        host="0.0.0.0",
+        host="0.0.0.0",  # nosec B104
         port=config.web_port,
         log_level=config.log_level.lower(),
     )

--- a/src/bifrost/auth.py
+++ b/src/bifrost/auth.py
@@ -25,7 +25,7 @@ def run_auth() -> None:
         print("Error: Username and password are required.", file=sys.stderr)
         sys.exit(1)
 
-    password_hash = hashlib.md5(password.encode("utf-8")).hexdigest()
+    password_hash = hashlib.md5(password.encode("utf-8"), usedforsecurity=False).hexdigest()  # nosec B324
 
     print("\nAuthenticating with Last.fm...")
 

--- a/src/bifrost/sonos_listener.py
+++ b/src/bifrost/sonos_listener.py
@@ -202,7 +202,7 @@ class SonosListener:
             if sub:
                 try:
                     sub.unsubscribe()
-                except Exception:
+                except Exception:  # nosec B110
                     pass
             logger.info("Removed speaker (no longer coordinator)", extra={"ip": ip})
 


### PR DESCRIPTION
## Summary
- Add `bandit` Python security linter to CI lint job
- Address existing findings with `nosec` annotations:
  - `B104`: Intentional bind to `0.0.0.0` for LAN access
  - `B324`: MD5 required by Last.fm API (added `usedforsecurity=False`)
  - `B110`: Best-effort cleanup in unsubscribe
- Add `bandit` to dev dependencies

## Test plan
- [x] `bandit -r src/` passes with 0 issues
- [x] All 120 tests pass
- [ ] CI lint job runs bandit successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)