### PR TITLE
Fix stats mobile padding clipping play counts

### DIFF
--- a/src/bifrost/web/static/style.css
+++ b/src/bifrost/web/static/style.css
@@ -871,7 +871,7 @@ main {
     }
 
     .stats-container {
-        padding: 16px;
+        padding: 0;
     }
 
     .stats-header {
@@ -884,14 +884,6 @@ main {
 
     .stats-total-count {
         font-size: 28px;
-    }
-
-    .stats-row {
-        padding: 8px 4px;
-    }
-
-    .stats-row-plays {
-        padding-right: 2px;
     }
 
     .history-section {


### PR DESCRIPTION
## Summary
- Remove double padding on mobile stats view — `.stats-container` had 16px padding on top of the parent `main` element's 16px, causing play count numbers to be clipped on the right edge
- Remove unnecessary `.stats-row` and `.stats-row-plays` mobile overrides that added extra horizontal padding

## Test plan
- [ ] Open the Stats tab on a mobile device (or narrow viewport ≤540px)
- [ ] Verify play count numbers are fully visible on the right side
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)