### PR TITLE
Fix WebSocket broadcasts not reaching frontend

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -194,16 +194,16 @@
         "filename": "tests/test_sonos_listener.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 87
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/test_sonos_listener.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 88
       }
     ]
   },
-  "generated_at": "2026-03-26T20:29:07Z"
+  "generated_at": "2026-03-26T20:30:37Z"
 }

--- a/src/bifrost/sonos_listener.py
+++ b/src/bifrost/sonos_listener.py
@@ -164,7 +164,7 @@ class SonosListener:
                     duration=action.track.duration_seconds or None,
                 )
 
-        if actions and self.on_state_change:
+        if self.on_state_change:
             self._broadcast_state()
 
     def _broadcast_state(self) -> None:
@@ -237,8 +237,6 @@ class SonosListener:
                     if transport_state:
                         actions = self.state_manager.handle_event(ip, transport_state, track_info)
                         self._process_actions(actions)
-                        if not actions:
-                            self._broadcast_state()
                 except Empty:
                     pass
                 except Exception:

--- a/src/bifrost/web/app.py
+++ b/src/bifrost/web/app.py
@@ -126,15 +126,20 @@ class WebApp:
     def broadcast(self, state: dict) -> None:
         """Called from the listener thread to push state updates."""
         self._current_state = state
-        if not self._loop:
+        if self._loop is None:
             return
-        stale: list[WebSocket] = []
         payload = json.dumps(state)
-        for ws in self._connections:
-            try:
-                asyncio.run_coroutine_threadsafe(ws.send_text(payload), self._loop)
-            except Exception:
-                stale.append(ws)
-        for ws in stale:
+        self._loop.call_soon_threadsafe(self._send_to_all, payload)
+
+    def _send_to_all(self, payload: str) -> None:
+        """Send payload to all connected WebSockets (runs on the event loop thread)."""
+        for ws in list(self._connections):
+            asyncio.ensure_future(self._safe_send(ws, payload))
+
+    async def _safe_send(self, ws: WebSocket, payload: str) -> None:
+        """Send to a single WebSocket, removing it on failure."""
+        try:
+            await ws.send_text(payload)
+        except Exception:
             if ws in self._connections:
                 self._connections.remove(ws)

--- a/tests/test_sonos_listener.py
+++ b/tests/test_sonos_listener.py
@@ -1,6 +1,5 @@
 """Tests for Sonos listener utilities and event parsing."""
 
-from queue import Empty
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -309,12 +308,12 @@ class TestProcessActions:
         listener._process_actions(actions)
         callback.assert_called_once()
 
-    def test_process_actions_no_broadcast_on_empty(self):
+    def test_process_actions_broadcasts_even_without_actions(self):
         callback = MagicMock()
         listener = _make_listener(on_state_change=callback)
 
         listener._process_actions([])
-        callback.assert_not_called()
+        callback.assert_called_once()
 
     def test_duration_zero_passed_as_none(self):
         scrobbler = MagicMock()
@@ -338,44 +337,21 @@ class TestBroadcastOnTransportEvent:
         state_manager = TrackStateManager()
         listener = _make_listener(state_manager=state_manager, on_state_change=callback)
 
-        speaker = MagicMock()
-        speaker.player_name = "Kitchen"
-        listener._speakers["192.168.1.10"] = speaker
-
         track = TrackInfo(title="Song", artist="Artist", duration_seconds=200)
 
         # Start playing and mark as scrobbled
         state_manager.handle_event("192.168.1.10", "PLAYING", track)
         ps = state_manager._states["192.168.1.10"]
         ps.scrobbled = True
+        callback.reset_mock()
 
-        # Build a STOPPED event
-        event = MagicMock()
-        event.variables = {
-            "transport_state": "STOPPED",
-            "current_track_meta_data": None,
-        }
-
-        sub = MagicMock()
-        sub.events.get.side_effect = [event, Empty()]
-        listener._subscriptions = {"192.168.1.10": sub}
-
-        # Process one iteration of the event loop inline
-        ip = "192.168.1.10"
-        transport_state, track_info = listener._parse_event(ip, event)
-        actions = state_manager.handle_event(ip, transport_state, track_info)
-
-        # No scrobble actions since already scrobbled
+        # Stop produces no scrobble actions since already scrobbled
+        actions = state_manager.handle_event("192.168.1.10", "STOPPED", None)
         assert len(actions) == 0
 
-        # But _process_actions + fallback broadcast should still notify UI
+        # _process_actions always broadcasts, even with empty actions
         listener._process_actions(actions)
-        # _process_actions won't broadcast (no actions), but the run loop does
-        # Simulate the run loop's fallback broadcast
-        if not actions:
-            listener._broadcast_state()
-
-        callback.assert_called()
+        callback.assert_called_once()
 
     def test_no_extra_broadcast_when_actions_present(self):
         """When actions are present, only _process_actions broadcasts (not double)."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -93,16 +93,23 @@ def test_broadcast_skips_send_without_loop(web_app):
     ws.send_text.assert_not_called()
 
 
-def test_broadcast_removes_stale_connections(web_app):
-    web_app._loop = MagicMock()
+def test_broadcast_schedules_on_loop(web_app):
+    loop = MagicMock()
+    web_app._loop = loop
+    web_app.broadcast({"test": "data"})
+    assert web_app._current_state == {"test": "data"}
+    loop.call_soon_threadsafe.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_safe_send_removes_stale_connection(web_app):
     stale_ws = MagicMock()
     stale_ws.send_text = MagicMock(side_effect=Exception("closed"))
     web_app._connections.append(stale_ws)
 
-    web_app.broadcast({"test": "data"})
+    await web_app._safe_send(stale_ws, '{"test": "data"}')
 
     assert stale_ws not in web_app._connections
-    assert web_app._current_state == {"test": "data"}
 
 
 def test_history_returns_recent_tracks():


### PR DESCRIPTION
## Summary
- Fix `broadcast()` using unreliable `asyncio.get_event_loop()` from listener thread — now captures uvicorn's running loop on first WS connect via `asyncio.get_running_loop()`
- Fix stopped speakers not disappearing from UI — broadcast state after any transport event, even when no scrobble actions are produced

## Test plan
- [ ] Start two speakers playing → both cards appear in real-time (no refresh needed)
- [ ] Stop one speaker → its card disappears from the UI immediately
- [ ] Clear a speaker's playlist → card is removed
- [ ] Verify single-speaker playback still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)